### PR TITLE
Fix _get_metric_tree endpoint

### DIFF
--- a/appd/request.py
+++ b/appd/request.py
@@ -192,7 +192,7 @@ class AppDynamicsClient(object):
         params = {}
         if parent:
             params['metric-path'] = parent.path
-        path = '/applications/%d/metrics' % app_id
+        path = '/controller/rest/applications/%d/metrics' % app_id
         nodes = MetricTreeNodes.from_json(self.request(path, params), parent)
         if recurse:
             for node in nodes:


### PR DESCRIPTION
_get_metric_tree was calling an endpoint that appears to have been deprecated.  Changed the path to reflect other calls that are succeeding